### PR TITLE
fix: simplificação do comando de build no GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,6 +19,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn package
       - name: Run tests with Maven
         run: mvn test


### PR DESCRIPTION
### Descrição do Merge:

**Objetivo**: Simplificar e otimizar o fluxo de trabalho de CI/CD no GitHub Actions, removendo parâmetros redundantes no comando de build do Maven.

#### O que foi feito:

* **Remoção do parâmetro `-B` (modo batch)**:

  * O comando `mvn -B package --file pom.xml` foi alterado para `mvn package`, já que o Maven executa o build em modo batch por padrão, e a inclusão do parâmetro `-B` é redundante em ambientes automatizados como o GitHub Actions.
* **Remoção do parâmetro `--file pom.xml`**:

  * O parâmetro `--file pom.xml` foi removido, pois o Maven automaticamente procura o arquivo `pom.xml` no diretório onde o comando é executado (o diretório raiz do repositório), tornando essa especificação desnecessária.

#### Benefícios:

* **Simplicidade**: O comando de build foi simplificado, tornando o fluxo de trabalho mais direto e fácil de entender.
* **Otimização**: A remoção de parâmetros redundantes pode tornar o processo de build ligeiramente mais eficiente.
* **Legibilidade**: O comando de build agora está mais limpo e alinhado com boas práticas, sem parâmetros desnecessários.

#### Impacto:

* Esta alteração não afeta a funcionalidade do processo de build, pois o Maven continuará a procurar o arquivo `pom.xml` no diretório correto e a executar o build em modo batch de forma padrão.