### PR TITLE
Atualiza dados de conexão para banco de dados hospedado na Render

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,8 @@
-#spring.datasource.url=jdbc:postgresql://dpg-d0b5ng6uk2gs73cdtl50-a.oregon-postgres.render.com:5432/overclock
-#spring.datasource.username=matheus_dev
-#spring.datasource.password=Z97BIKEWkVkwGCokAGdQPBT6ZTMX7vKW
+# application.properties
+spring.datasource.url=jdbc:postgresql://dpg-d0dc03uuk2gs73cv3nh0-a.oregon-postgres.render.com/overclock_qfp9
+spring.datasource.username=matheus_dev
+spring.datasource.password=HVITA2RoLcVtHTx9kd0XONMyF45wZEYD
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/overclock_local
-spring.datasource.username=postgres
-spring.datasource.password=150304
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
### ERRO DE BANCOS COM BANCO EM PRODUÇÃO

## 🛑 **Erros Encontrados**

1. **Configuração incorreta do banco de dados nos testes:**

   * Durante a execução dos testes automatizados, o sistema estava tentando se conectar a um banco de dados **MySQL** ou **PostgreSQL externo** (hospedado no Render). Isso resultou em falhas, pois:

     * O banco de dados do Render não estava acessível para os testes durante o processo de CI/CD.
     * O código de teste estava tentando se conectar a um banco real, o que não é adequado para o ambiente de testes, onde um banco em memória seria mais indicado.

2. **Dependência de recursos externos para testes:**

   * O uso de um banco de dados remoto para os testes exigia uma conexão ativa com a internet e a disponibilidade do serviço externo (Render.com). Esse tipo de dependência não é ideal para ambientes de teste automatizados, pois pode causar falhas devido a problemas de conectividade ou disponibilidade do serviço externo.

3. **Falta de isolamento nos testes:**

   * Os testes estavam sendo executados contra o banco de dados real, o que não isola as operações de leitura e gravação dos testes. Isso pode interferir nos dados de produção ou desenvolvimento, além de ser mais lento e menos confiável.

4. **Configuração inadequada do `application.properties`:**

   * O arquivo `application.properties` estava configurado com valores para o banco de dados em produção e local, mas os testes estavam tentando utilizar essas configurações, o que não era desejável.

---

### ✅ **Soluções Aplicadas**

1. **Separação de ambientes (produção e testes):**

   * Foi criado um arquivo de configuração específico para os testes (`application-test.properties`), configurando o uso do banco H2 em memória para os testes. Isso permite que os testes sejam rápidos, isolados e não dependam de serviços externos.

   * O arquivo `application.properties` foi mantido para uso em produção e desenvolvimento, apontando para o banco de dados PostgreSQL do Render.

2. **Configuração correta do banco de dados em produção:**

   * A configuração do banco de dados em produção (PostgreSQL no Render) foi mantida no arquivo `application.properties` para garantir que o ambiente de desenvolvimento e produção continue funcionando corretamente.

   * Para garantir que os testes automatizados não interfiram no banco de dados real, um banco de dados em memória (H2) foi configurado no arquivo `application-test.properties`.

3. **Uso do perfil de teste:**

   * Foi utilizado o `@ActiveProfiles("test")` nos testes para garantir que o Spring carregue o banco de dados em memória durante a execução dos testes. Isso evita interações com bancos reais, mantendo a integridade dos dados de produção e reduzindo a dependência de redes externas.

   * A criação do perfil de teste permite que o ambiente de CI/CD utilize configurações específicas de teste, que não interferem no funcionamento do aplicativo em produção.

4. **Eliminação de dependências externas:**

   * Com a configuração do banco em memória (H2), os testes não dependem mais da conectividade externa, tornando o processo de CI/CD mais estável e eficiente. Isso melhora a confiabilidade do fluxo de integração contínua, pois o ambiente de teste agora é completamente isolado e autossuficiente.

5. **Adição da dependência do H2:**

   * A dependência do H2 foi adicionada ao `pom.xml` para garantir que o banco em memória esteja disponível durante os testes. Isso elimina a necessidade de configurar um banco real para os testes.

   ```xml
   <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>
   </dependency>
   ```

---

### ✅ **Resultado final**

Com essa solução aplicada:

* Os testes agora rodam de forma confiável e isolada, sem impactar o banco de dados real utilizado em produção.
* O código continua utilizando o banco do Render (PostgreSQL) em produção, enquanto os testes são executados com um banco H2 em memória.
* O ambiente de CI/CD (como GitHub Actions) não falha por dependência de conexão externa, o que melhora a confiabilidade do pipeline.
* A separação de ambientes para produção e testes segue as boas práticas de desenvolvimento, garantindo que a aplicação continue estável enquanto os testes são executados de maneira isolada e sem interferências externas.

Agora, o código está mais robusto e pronto para ser executado tanto em ambientes de desenvolvimento como em produção, sem risco de falhas durante o processo de CI/CD ou de testes.